### PR TITLE
docs(README.md): Add definition for `alpha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ If the specified array of *nodes* is modified, such as when nodes are added to o
 
 <a name="simulation_alpha" href="#simulation_alpha">#</a> <i>simulation</i>.<b>alpha</b>([<i>alpha</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L98 "Source")
 
+The *alpha* is the “energy” of the graph at a particular moment in time. Alpha starts high and decreases over time, and when alpha goes past a certain number, the graph stops moving. 
+
 If *alpha* is specified, sets the current alpha to the specified number in the range [0,1] and returns this simulation. If *alpha* is not specified, returns the current alpha value, which defaults to 1.
 
 <a name="simulation_alphaMin" href="#simulation_alphaMin">#</a> <i>simulation</i>.<b>alphaMin</b>([<i>min</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L102 "Source")


### PR DESCRIPTION
- Alpha didn't have a meaningful definition and assumed people already knew what it was.
- Credit for definition: http://www.puzzlr.org/basics-of-d3-force-directed-graphs/